### PR TITLE
Add support for priority.

### DIFF
--- a/bbb/servicebase.py
+++ b/bbb/servicebase.py
@@ -272,7 +272,9 @@ class BuildbotDb(object):
 
         # Create the buildrequest
         buildername = payload['buildername']
-        priority = payload.get('priority', 0)
+        priority = 0
+        if task.get("priority") == "high":
+            priority = 1
         q = self.buildrequests_table.insert().values(
             buildsetid=buildsetid,
             buildername=buildername,


### PR DESCRIPTION
Turns out that @catlee planned for this originally by looking for it in the sourcestamp. This is a simple patch now that just looks in the task definition instead! I also added a test.